### PR TITLE
Support pull_request trigger in Github Actions

### DIFF
--- a/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -23,6 +23,20 @@ env:
 
 
 jobs:
+  set_checkout_ref:
+    runs-on: ubuntu-latest
+    outputs:
+      checkout_ref: ${{ steps.set_checkout_ref.outputs.checkout_ref }}
+    steps:
+      - name: Set checkout reference
+        id: set_checkout_ref
+        run: |
+          if [ ${{ github.event_name }} == 'push' ]; then
+            echo "::set-output name=checkout_ref::${{ github.ref }}"
+          elif [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            echo "::set-output name=checkout_ref::${{ github.event.pull_request.head.ref }}"
+          fi
+
   configure_env_vars:
     container:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4

--- a/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -42,9 +42,12 @@ jobs:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
       options: --user root
     runs-on: ubuntu-latest
+    needs: set_checkout_ref
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{needs.set_checkout_ref.outputs.checkout_ref}}
 
       - name: Set bash_env env var
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
@@ -92,13 +95,17 @@ jobs:
           echo "export ARTIFACTS_DIR_URL='${GITHUB_WORKFLOW_URL}/#artifacts'" >> $BASH_ENV
 
   static_tests:
+
     container:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
       options: --user root
     runs-on: ubuntu-latest
+    needs: set_checkout_ref
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{needs.set_checkout_ref.outputs.checkout_ref}}
 
       - name: Cache composer cache
         uses: actions/cache@v2
@@ -129,11 +136,12 @@ jobs:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
       options: --user root
     runs-on: ubuntu-latest
-    needs: [configure_env_vars, static_tests]
+    needs: [set_checkout_ref, configure_env_vars, static_tests]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{needs.set_checkout_ref.outputs.checkout_ref}}
           fetch-depth: 0
 
       - name: Set bash_env env var

--- a/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -80,7 +80,6 @@ jobs:
           echo "export ARTIFACTS_DIR_URL='${GITHUB_WORKFLOW_URL}/#artifacts'" >> $BASH_ENV
 
   static_tests:
-
     container:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
       options: --user root
@@ -206,6 +205,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Set bash_env env var
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
@@ -317,6 +318,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
 
       - name: Set bash_env env var

--- a/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -23,31 +23,16 @@ env:
 
 
 jobs:
-  set_checkout_ref:
-    runs-on: ubuntu-latest
-    outputs:
-      checkout_ref: ${{ steps.set_checkout_ref.outputs.checkout_ref }}
-    steps:
-      - name: Set checkout reference
-        id: set_checkout_ref
-        run: |
-          if [ ${{ github.event_name }} == 'push' ]; then
-            echo "::set-output name=checkout_ref::${{ github.ref }}"
-          elif [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=checkout_ref::${{ github.event.pull_request.head.ref }}"
-          fi
-
   configure_env_vars:
     container:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
       options: --user root
     runs-on: ubuntu-latest
-    needs: set_checkout_ref
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{needs.set_checkout_ref.outputs.checkout_ref}}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Set bash_env env var
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
@@ -100,12 +85,11 @@ jobs:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
       options: --user root
     runs-on: ubuntu-latest
-    needs: set_checkout_ref
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{needs.set_checkout_ref.outputs.checkout_ref}}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Cache composer cache
         uses: actions/cache@v2
@@ -136,12 +120,12 @@ jobs:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
       options: --user root
     runs-on: ubuntu-latest
-    needs: [set_checkout_ref, configure_env_vars, static_tests]
+    needs: [configure_env_vars, static_tests]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{needs.set_checkout_ref.outputs.checkout_ref}}
+          ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
 
       - name: Set bash_env env var


### PR DESCRIPTION
Coming from CircleCI to Github Actions, I attempted to switch to pull_request being the trigger instead of the push. In CircleCI this is set in the project settings, but in Github Actions, has to be set as the workflow trigger. This lead to odd behavior and it turned out it was because unless defined specifically, [actions/checkout](https://github.com/actions/checkout) uses the github.ref variable by default, but this value differs between push and pull_request triggers. From the [Github Actions docs](https://docs.github.com/en/actions/learn-github-actions/contexts):

>For workflows triggered by push, this is the branch or tag ref that was pushed. For workflows triggered by pull_request, this is the pull request merge branch.

This PR introduces a new job called `set_checkout_ref` which checks if the triggered event is push or pull_request, and sets a [job output](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs) variable equal to `github.ref` if using the push trigger, or `github.event.pull_request.head.ref` for pull_request. It makes all subsequent jobs dependent on this first step, so that the output variable can be accessed, and sets it as the ref for the actions/checkout step so that the correct reference is set.

More info on this behavior: https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout

I'm opening this agains the d9 file because that's where I'm working, but the behavior could be added to the rest of the templates easily, I think.

Thanks.