### PR TITLE
Update environment vars to use Github Actions contexts

### DIFF
--- a/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -48,28 +48,14 @@ jobs:
       - name: setup-environment-vars
         run: |
           if [ "$CI_BRANCH" != "refs/heads/master" ]; then
-            export PR_NUMBER=`curl -u "${GITHUB_OWNER}:${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github.groot-preview+json" \
-              "https://api.github.com/repos/${CI_PROJECT_NAME}/commits/${COMMIT_SHA}/pulls" | \
-              python3 -c "import sys, json; print(json.load(sys.stdin)[0]['number'])"`
-
-            export CI_BRANCH=`curl -u "${GITHUB_OWNER}:${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github.groot-preview+json" \
-              "https://api.github.com/repos/${CI_PROJECT_NAME}/commits/${COMMIT_SHA}/pulls" | \
-              python3 -c "import sys, json; print(json.load(sys.stdin)[0]['head']['ref'])"`
-
-            export CI_PULL_REQUEST=`curl -u "${GITHUB_OWNER}:${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github.groot-preview+json" \
-              "https://api.github.com/repos/${CI_PROJECT_NAME}/commits/${COMMIT_SHA}/pulls" | \
-              python3 -c "import sys, json; print(json.load(sys.stdin)[0]['html_url'])"`
+            export PR_NUMBER=${{ github.event.number }}
+            export CI_BRANCH=${{ github.head_ref }}
+            export CI_PULL_REQUEST=${{ github.event.pull_request._links.html.href }}
           else
             export CI_BRANCH="master"
           fi
-          export CI_PROJECT_REPONAME=`curl -u "${GITHUB_OWNER}:${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github.groot-preview+json" \
-            "https://api.github.com/repos/${CI_PROJECT_NAME}/commits/${COMMIT_SHA}/pulls" | \
-            python3 -c "import sys, json; print(json.load(sys.stdin)[0]['base']['repo']['name'])"`
-          export CI_PROJECT_USERNAME=$GITHUB_REPOSITORY_OWNER
+          export CI_PROJECT_REPONAME=${GITHUB_REPOSITORY#*/}
+          export CI_PROJECT_USERNAME=${GITHUB_REPOSITORY_OWNER}
           /build-tools-ci/scripts/set-environment
           GITHUB_WORKFLOW_URL=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
           echo "export CI_BUILD_URL='${GITHUB_WORKFLOW_URL}'" >> $BASH_ENV

--- a/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -5,7 +5,6 @@ defaults:
     shell: bash
 env:
   TZ: "/usr/share/zoneinfo/America/Los_Angeles"
-  NOTIFY: 'scripts/github/add-commit-comment {project} {sha} "Created multidev environment [{site}#{env}]({dashboard-url})." {site-url}'
   TERM: dumb
   ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
   ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
@@ -13,14 +12,15 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
   TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
   TEST_SITE_NAME: ${{ secrets.TERMINUS_SITE }}
-  CI_BRANCH: ${{ github.ref }}
+  CI_BRANCH: $GITHUB_REF_NAME
   COMMIT_SHA: ${{ github.sha }}
   CI_BUILD_NUMBER: ${{ github.run_number }}
   DEFAULT_SITE: ${{ secrets.TERMINUS_SITE }}
   SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
   GITHUB_OWNER: ${{ github.repository_owner }}
   CI_PROJECT_NAME: ${{ github.repository }}
-
+  PR_NUMBER: ${{ github.event.number }}
+  CI_PULL_REQUEST: ${{ github.event.pull_request._links.html.href }}
 
 jobs:
   configure_env_vars:
@@ -47,13 +47,21 @@ jobs:
       # https://github.com/pantheon-systems/docker-build-tools-ci/blob/6.x/scripts/set-environment
       - name: setup-environment-vars
         run: |
-          if [ "$CI_BRANCH" != "refs/heads/master" ]; then
-            export PR_NUMBER=${{ github.event.number }}
-            export CI_BRANCH=${{ github.head_ref }}
-            export CI_PULL_REQUEST=${{ github.event.pull_request._links.html.href }}
-          else
-            export CI_BRANCH="master"
+          # Test vars not set means trigger = push.
+          if [ -z "$PR_NUMBER" ]; then
+            export PR_NUMBER=`curl -u "${GITHUB_OWNER}:${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github.groot-preview+json" \
+              "https://api.github.com/repos/${CI_PROJECT_NAME}/commits/${COMMIT_SHA}/pulls" | \
+              jq '.[0].number'`
           fi
+
+          if [ -z "$CI_PULL_REQUEST" ]; then
+            export CI_PULL_REQUEST=`curl -u "${GITHUB_OWNER}:${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github.groot-preview+json" \
+              "https://api.github.com/repos/${CI_PROJECT_NAME}/commits/${COMMIT_SHA}/pulls" | \
+              jq '.[0].html_url'`
+          fi
+
           export CI_PROJECT_REPONAME=${GITHUB_REPOSITORY#*/}
           export CI_PROJECT_USERNAME=${GITHUB_REPOSITORY_OWNER}
           /build-tools-ci/scripts/set-environment


### PR DESCRIPTION
In working on #9  I thought some of this could be simplified to using existing Github Actions contexts.

`CI_PROJECT_REPONAME` and `CI_PROJECT_USERNAME` can be derived from existing environment variables and the former can be reduced to the repo using string manipulation.

Thanks.