### PR TITLE
Set CI_BRANCH env variable from context based on event

### DIFF
--- a/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -12,7 +12,7 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
   TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
   TEST_SITE_NAME: ${{ secrets.TERMINUS_SITE }}
-  CI_BRANCH: $GITHUB_REF_NAME
+  CI_BRANCH: ${{ github.head_ref || github.ref_name }}
   COMMIT_SHA: ${{ github.sha }}
   CI_BUILD_NUMBER: ${{ github.run_number }}
   DEFAULT_SITE: ${{ secrets.TERMINUS_SITE }}


### PR DESCRIPTION
`$GITHUB_REF_NAME` doesn't seem to be working here for CI_BRANCH. It's attempting to create multidevs called pr-null. I get the correct value when I set it from Github Actions context. Looks like it was also failing here to set the correct value here: https://github.com/kporras07/cms-613-ga2/runs/7331200160?check_suite_focus=true#step:6:64

I'm taking the same convention from #9 to set it correctly based on event. Thanks!