### PR TITLE
Add env:wake to make sure database is reachable

### DIFF
--- a/d9/.ci/deploy/pantheon/dev-multidev
+++ b/d9/.ci/deploy/pantheon/dev-multidev
@@ -23,6 +23,9 @@ else
   terminus -n build:env:push "$TERMINUS_SITE.dev" --yes
 fi
 
+# Wake the environment to make sure the database is reachable.
+terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV"
+
 # Update the Drupal database
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y
 

--- a/wp/.ci/deploy/pantheon/dev-multidev
+++ b/wp/.ci/deploy/pantheon/dev-multidev
@@ -26,6 +26,9 @@ else
     terminus -n build:env:push "$TERMINUS_SITE.dev" --yes
 fi
 
+# Wake the environment to make sure the database is reachable.
+terminus -n env:wake "$TERMINUS_SITE.$TERMINUS_ENV"
+
 # Run update-db to ensure that the cloned database is updated for the new code.
 terminus -n wp $TERMINUS_SITE.$TERMINUS_ENV -- core update-db
 


### PR DESCRIPTION
Following up on this Slack thread: https://pantheon-community.slack.com/archives/C57J1MUEM/p1660148365952049

We continue to hit on failures in Github Actions during the `deploy_to_pantheon` step when `drush updatedb` runs:

```
Notice: ] Creating multidev ci-4 for site ***
Notice: ] Created Multidev environment "ci-4"
Notice: ] Enabled on-server development via SFTP for "ci-4"
Notice: ] Call GitHub API: POST repos/::removed::/::removed::/commits/e684b6c2c280472f3fb6dbba3de614583ef97d40/comments
Warning: Permanently added '[appserver.ci-4.::removed::drush.in]:2222,[35.226.56.23]:2222' (RSA) to the list of known hosts.
Notice: ] Command: ***.ci-4 -- drush updatedb [Exit: 137]
Error: ]  SQLSTATE[HY000] [2002] Connection refused 
SQLSTATE[HY000] [2002] Connection refused
Error: Process completed with exit code 1.
```

Adding `env:wake` right before has fixed this. Thanks!