### PR TITLE
Update all actions to v4

### DIFF
--- a/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
@@ -38,7 +38,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:
@@ -83,12 +83,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -119,7 +119,7 @@ jobs:
     needs: [configure_env_vars, static_tests]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
@@ -128,7 +128,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:
@@ -140,7 +140,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -152,7 +152,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache vendor folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-vendor
         with:
@@ -160,7 +160,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache web folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-web
         with:
@@ -168,7 +168,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}
 
       - name: Cache drush folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-drush
         with:
@@ -203,7 +203,7 @@ jobs:
     needs: [deploy_to_pantheon]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
@@ -211,7 +211,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:
@@ -223,7 +223,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -235,7 +235,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache vendor folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-vendor
         with:
@@ -243,7 +243,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache web folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-web
         with:
@@ -251,7 +251,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}
 
       - name: Cache drush folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-drush
         with:
@@ -294,7 +294,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: behat-report
           path: /tmp/artifacts
@@ -308,7 +308,7 @@ jobs:
     needs: [configure_env_vars, behat_test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
@@ -317,7 +317,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:
@@ -329,7 +329,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -341,7 +341,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache vendor folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-vendor
         with:
@@ -349,7 +349,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache web folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-web
         with:
@@ -357,7 +357,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}
 
       - name: Cache drush folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-drush
         with:
@@ -373,7 +373,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vrt-report
           path: /tmp/artifacts

--- a/d9/providers/githubactions/.ci/.github/workflows/scheduled_update_check.yml
+++ b/d9/providers/githubactions/.ci/.github/workflows/scheduled_update_check.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:

--- a/wp/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
+++ b/wp/providers/githubactions/.ci/.github/workflows/build_deploy_and_test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
@@ -38,7 +38,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:
@@ -83,12 +83,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -115,12 +115,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -132,7 +132,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache vendor folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-vendor
         with:
@@ -140,7 +140,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache web folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-web
         with:
@@ -148,7 +148,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}
 
       - name: Cache drush folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-drush
         with:
@@ -174,7 +174,7 @@ jobs:
     needs: [configure_env_vars, static_tests, build_php]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref || github.ref_name }}
@@ -183,7 +183,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:
@@ -195,7 +195,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -207,7 +207,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache vendor folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-vendor
         with:
@@ -215,7 +215,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache web folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-web
         with:
@@ -223,7 +223,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}
 
       - name: Cache drush folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-drush
         with:
@@ -260,7 +260,7 @@ jobs:
     needs: [deploy_to_pantheon]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
@@ -268,7 +268,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:
@@ -280,7 +280,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -292,7 +292,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache vendor folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-vendor
         with:
@@ -300,7 +300,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache web folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-web
         with:
@@ -308,7 +308,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}
 
       - name: Cache drush folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-drush
         with:
@@ -351,7 +351,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: behat-report
           path: /tmp/artifacts
@@ -365,7 +365,7 @@ jobs:
     needs: [configure_env_vars, behat_test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref || github.ref_name }}
@@ -374,7 +374,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:
@@ -386,7 +386,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache composer cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-composer-cache
         with:
@@ -398,7 +398,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache vendor folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-vendor
         with:
@@ -406,7 +406,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache web folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-web
         with:
@@ -414,7 +414,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_number }}
 
       - name: Cache drush folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-drush
         with:
@@ -430,7 +430,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vrt-report
           path: /tmp/artifacts

--- a/wp/providers/githubactions/.ci/.github/workflows/scheduled_update_check.yml
+++ b/wp/providers/githubactions/.ci/.github/workflows/scheduled_update_check.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
         run: echo BASH_ENV=${RUNNER_TEMP}/bash_env.txt >> $GITHUB_ENV
 
       - name: Cache bash_env.txt
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-bash-env
         with:


### PR DESCRIPTION
actions/checkout@v3 is causing node16 deprecation warnings on runs:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Haven't seen any issues using latest v4 for all actions in our project, so this PR updates them all to v4.