### PR TITLE
Re-add build-assets step for d9

### DIFF
--- a/d9/.ci/deploy/pantheon/dev-multidev
+++ b/d9/.ci/deploy/pantheon/dev-multidev
@@ -9,6 +9,9 @@ set -eo pipefail
 #
 
 # Cut gitignore at the cut mark.
+terminus build:gitignore:cut
+
+# Run build-assets script in case it is needed.
 composer -n build-assets
 
 # Authenticate with Terminus

--- a/d9/.ci/deploy/pantheon/dev-multidev
+++ b/d9/.ci/deploy/pantheon/dev-multidev
@@ -9,7 +9,7 @@ set -eo pipefail
 #
 
 # Cut gitignore at the cut mark.
-terminus build:gitignore:cut
+composer -n build-assets
 
 # Authenticate with Terminus
 terminus -n auth:login --machine-token="$TERMINUS_TOKEN"


### PR DESCRIPTION
Not sure why the build-assets step is not present in the d9 template set, but here's the fix I used to get the project building.

ref https://github.com/pantheon-systems/tbt-ci-templates/issues/29